### PR TITLE
feat: update for leland migration

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,11 @@
 import os
+import time
 from dotenv import load_dotenv
 from rich import print as rprint
 from rich.console import Console
+from rich.progress import Progress
 
-from src.utils import get_valid_date_range, validate_env
+from src.utils import get_valid_date_range, validate_env, chunk_date_range, get_chunk_size
 from src.mixpanel_exporter import MixpanelExporter
 from src.posthog_importer import posthog_import
 
@@ -30,35 +32,44 @@ def main():
     rprint("[yellow]You may crash your machine if you try to export too much data at once.\n[/yellow]")
     
     from_dt, to_dt = get_valid_date_range()
+    chunk_size = get_chunk_size()
+    
+    # Split date range into chunks
+    date_chunks = chunk_date_range(from_dt, to_dt, chunk_size)
+    total_chunks = len(date_chunks)
+    
+    rprint(f"\n[blue]Processing {total_chunks} chunks of {chunk_size} days each[/blue]")
+    rprint(f"[blue]Total date range: {from_dt.strftime('%Y-%m-%d')} to {to_dt.strftime('%Y-%m-%d')}[/blue]")
 
-    # Export from Mixpanel and import to Posthog
-    rprint("[blue]Exporting data from Mixpanel (This may take awhile)[/blue]")
-
-    with console.status("[bold blue]Exporting data from Mixpanel (This may take a while)...", spinner="dots") as status:
-        try:
-            exporter = MixpanelExporter(
-                version=VERSION,
-                api_url=MIXPANEL_API_URL,
-                username=os.getenv("MIXPANEL_USERNAME"),
-                password=os.getenv("MIXPANEL_PASSWORD"),
-                project_id=os.getenv("MIXPANEL_PROJECT_ID"),
-                from_date=from_dt,
-                to_date=to_dt
-            )
-            # You can update the status message dynamically inside the block
-            status.update("[bold yellow]Exporting data from Mixpanel...", spinner="earth") # Example update
-            data = exporter.export()
-
-            # Change status message for the next phase
-            status.update("[bold magenta]Importing data to Posthog...", spinner="line") # Example update
-            posthog_import(data)
-
-        except Exception as e:
-            rprint(f"[red]Error during export/import: {str(e)}[/red]")
-            exit(1)
-
-
-    rprint("[green]Successfully imported data to Posthog[/green]")
+    start_time = time.time()
+    
+    with Progress() as progress:
+        task = progress.add_task("[cyan]Processing chunks...", total=total_chunks)
+        
+        for chunk_start, chunk_end in date_chunks:
+            progress.update(task, description=f"[cyan]Processing {chunk_start.strftime('%Y-%m-%d')} to {chunk_end.strftime('%Y-%m-%d')}")
+            
+            try:
+                chunk_exporter = MixpanelExporter(
+                    version=VERSION,
+                    api_url=MIXPANEL_API_URL,
+                    username=os.getenv("MIXPANEL_USERNAME"),
+                    password=os.getenv("MIXPANEL_PASSWORD"),
+                    project_id=os.getenv("MIXPANEL_PROJECT_ID"),
+                    from_date=chunk_start,
+                    to_date=chunk_end
+                )
+                
+                data = chunk_exporter.export()
+                posthog_import(data)
+                
+            except Exception as e:
+                rprint(f"\n[red]Error processing chunk {chunk_start.strftime('%Y-%m-%d')} to {chunk_end.strftime('%Y-%m-%d')}: {str(e)}[/red]")
+                exit(1)
+            
+            progress.advance(task)
+    total_time = time.time() - start_time
+    rprint(f"[green]Successfully imported all data to Posthog[/green] in {total_time:.2f} seconds / {total_time/60:.2f} minutes")
 
 if __name__ == "__main__":
     main() 

--- a/src/mapping.py
+++ b/src/mapping.py
@@ -1,0 +1,82 @@
+name_mapping = {
+    # Apply page events
+    'typeformSubmissionError': 'applicant_apply--typeform_submission_error',
+    'completedApplicantTypeform': 'applicant_apply--typeform_submission_success',
+    
+    # Auth events
+    'applicantSignUp': 'applicant_sign_up',
+    
+    # Message events
+    'firstMessageSent': 'first_message_send',
+    
+    # Session events
+    'coachingSessionScheduled': 'coaching_session_scheduled',
+    'introCallScheduled': 'intro_call_scheduled',
+    
+    # Subscription events
+    'subscriptionStarted': 'manage_subscription--subscription_start',
+    'subscriptionCanceled': 'manage_subscription--subscription_cancel',
+    
+    # Purchase events
+    'purchase': 'purchase_complete',
+    'completeGuestCheckout': 'checkout--guest_checkout_complete',
+    'completeGuestSignup': 'checkout--guest_signup_complete',
+    
+    # Event card events
+    'Click Event Card Register - Navigate to Luma': 'event_card--navigate_to_luma_click',
+    'EventCard Click': 'event_card--click',
+    
+    # Vouch events
+    'Vouch Modal Open': 'vouch_modal--open',
+    'Vouch Modal Submit': 'vouch_modal--submit',
+    'Vouch Outcome Submit': 'vouch_outcome_step--submit',
+    
+    # Events page events
+    'EventsPage - click - Class': 'events_page--class_card_click',
+    
+    # Coach events
+    'viewedIntroVideo': 'coach_profile--intro_video_view',
+    'viewedCoachProfile': 'coach_profile--view',
+    'clickedMessageCoach': 'coach_message_cta--message_coach_click',
+    'coachMessageCTA - messaged coach': 'coach_message_cta--message_coach_success',
+    
+    # Schedule modal events
+    'SCHEDULE_MODAL_EVENTS.STEP_CHANGE': 'schedule_modal--step_change',
+    'SCHEDULE_MODAL_EVENTS.CLOSE': 'schedule_modal--close',
+    
+    # Search events
+    'clickedSRPPackage' : 'srp--leland_package_click',
+    'SRP - click - Search Bar': 'srp--search_bar_focus',
+    'SRP - filter - Search Bar': 'srp--search_bar_filter',
+    'SRP - click - Featured Filter': 'srp--featured_filter_click',
+    'SRP - click - Booked Coach': 'srp--booked_coach_click',
+    'Cohort Banner Click': 'srp--cohort_banner_click',
+    'SRP - click - Class': 'srp--class_click',
+    'SRP - click - Leland Package': 'srp--leland_package_click',
+    'SRP - click - View more packages': 'srp--view_more_packages_click',
+    'SRP - click - Offering Package': 'srp--offering_package_click',
+    'SRP - click - Sort': 'srp--coach_filter_section_sort',
+    'SRP - click - Coach Card': 'srp--coach_card_click',
+    'SRP - click - Coach Pagination': 'srp--coach_pagination_click',
+    'SRP - click - Talk to a Team Member button': 'srp--talk_to_a_team_member_button_click',
+    
+    # Class events
+    'Enroll Free Event': 'free_event--enroll',
+    'Unenroll Free Event': 'free_event--unenroll',
+    
+    # Meeting events
+    'coachingSessionAttended': 'meeting--coaching_session_attend',
+ 
+    # Bootcamp events
+    'Bootcamp Card Click': 'bootcamp_card--click',
+
+    # Article events
+    'Article - Subscribe': 'article_page--email_list_subscribe',
+    'Article - Schedule a strategy call': 'article_page--schedule_call_button_click',
+
+    # Event Banner
+    'Event Banner Click':'article_page--event_banner_click',
+
+    # Page View
+    "pageView": "$pageview",
+}

--- a/src/mixpanel_exporter.py
+++ b/src/mixpanel_exporter.py
@@ -74,8 +74,8 @@ class MixpanelExporter:
                 if formatted_data["distinct_id"] and formatted_data["time"]:
                     events.append(formatted_data)
                     event_count += 1
-                    if event_count % 100 == 0:
-                        log.info("Processed events", extra={"count": event_count})
+                    if event_count % 1000 == 0:
+                        log.info(f"Processed {event_count} events")
                 else:
                     log.info("Skipping event with no distinct_id or time", extra={"event": formatted_data["event"]})
 
@@ -83,7 +83,7 @@ class MixpanelExporter:
                 log.error(f"Error decoding JSON: {str(e)}")
                 continue
 
-        log.info("Finished reading events", extra={"total_events": event_count})
+        log.info(f"Finished reading {event_count} events", extra={"total_events": event_count})
         return events
 
     def _format_data_line(self, line: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/posthog_importer.py
+++ b/src/posthog_importer.py
@@ -3,9 +3,27 @@ import time
 from typing import List, Dict, Any
 from posthog import Posthog
 from rich import print as rprint
+from src.mapping import name_mapping
 
 # Constants
 DELAY_MS = 1  # Delay between posthog queue events to avoid overloading the API
+
+def map_event_name(event: str, properties: Dict[str, Any]) -> str:
+    """Map Mixpanel event names to PostHog event names."""
+    # Handle special case for Leland+ Banner Click
+    if event == 'Leland+ Banner Click':
+        source = properties.get('source', '').lower()
+        if source == 'srp':
+            return 'srp--leland_plus_banner_click'
+        elif source == 'article':
+            return 'article_page--leland_plus_banner_click'
+        elif source == 'post_checkout':
+            return 'post_checkout--leland_plus_banner_click'
+        else:
+            return 'leland_plus_banner--click'
+    
+    # Handle regular mappings - if not found in mapping, return original event name
+    return name_mapping.get(event, event)
 
 def posthog_import(data: List[Dict[str, Any]]) -> None:
     """Import events from Mixpanel to Posthog."""
@@ -14,6 +32,9 @@ def posthog_import(data: List[Dict[str, Any]]) -> None:
     for line in data:
         if line["event"] == "$mp_web_page_view":
             line["event"] = "$pageview"
+        else:
+            # Map the event name using our mapping function
+            line["event"] = map_event_name(line["event"], line["properties"])
         
         # Construct properties
         properties = {}

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,7 +1,7 @@
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 from rich import print as rprint
-from rich.prompt import Prompt
+from rich.prompt import Prompt, IntPrompt
 
 def validate_env():
     # Check if Mixpanel credentials are in env
@@ -36,3 +36,37 @@ def get_valid_date_range():
             rprint("[red]Invalid date format. Please use YYYY-MM-DD[/red]")
     
     return from_dt, to_dt
+
+def get_chunk_size() -> int:
+    """Get the chunk size in days from the user."""
+    while True:
+        chunk_size = IntPrompt.ask(
+            "Enter chunk size in days",
+            default=7,
+            show_default=True
+        )
+        if chunk_size > 0:
+            return chunk_size
+        rprint("[red]Chunk size must be greater than 0[/red]")
+
+def chunk_date_range(from_date: datetime, to_date: datetime, chunk_size_days: int = 7) -> list[tuple[datetime, datetime]]:
+    """
+    Split a date range into smaller chunks.
+    
+    Args:
+        from_date: Start date
+        to_date: End date
+        chunk_size_days: Number of days in each chunk (default: 7)
+    
+    Returns:
+        List of (chunk_start, chunk_end) datetime tuples
+    """
+    chunks = []
+    current_date = from_date
+    
+    while current_date < to_date:
+        chunk_end = min(current_date + timedelta(days=chunk_size_days), to_date)
+        chunks.append((current_date, chunk_end))
+        current_date = chunk_end + timedelta(days=1)
+    
+    return chunks


### PR DESCRIPTION
This makes a few changes to the original ported script
1. Breaks date range into chunks to help with Mixpanel rate limiting (note that Mixpanel doesn't do batch gets, so you are advised to request < 100,000 events per call). Allows for setting a large time range and automating calls to Mixpanel
2. Allows for user to input a chunk size (in days). The idea here is we can look at our graph of Mixpanel events and input a chunk size that will allow our request to remain under the 100k limit.
3. Remaps event names from old mixpanel ones to posthog conventions
4. Better info logging


Note that I've build both Go and Python scripts with the `historicalMigration: true` flag. There is a slight performance improvement when using the Go script 

For ~ 50,000 events -> Go : 1:40, Python 2:01


Planning on using this graph (the prod version) to determine chunk size

<img width="1996" alt="Screenshot 2025-06-11 at 12 29 05 PM" src="https://github.com/user-attachments/assets/f61cb351-e0da-4f95-b8fb-f2f1857281d9" />


<img width="1254" alt="Screenshot 2025-06-11 at 12 29 45 PM" src="https://github.com/user-attachments/assets/ff68df48-d94a-47aa-bbd7-af355721419c" />

https://github.com/user-attachments/assets/4f8b99d0-ecaa-4cd4-a7be-3d8b64385687



